### PR TITLE
Project index page shouldn't fail to load due to web services

### DIFF
--- a/grails-app/services/au/org/ala/biocollect/merit/CollectoryService.groovy
+++ b/grails-app/services/au/org/ala/biocollect/merit/CollectoryService.groovy
@@ -3,40 +3,51 @@ package au.org.ala.biocollect.merit
 import grails.core.GrailsApplication
 
 
-
 /**
- * Licences provided by Collectory service are not fully supported by BioCollect,
- * Neither enough information for licences needed by BioCollect
+ * Licences provided by Collectory service are not fully supported by BioCollect.
+ * Combine information from Biocollect and Collectory.
  */
 class CollectoryService {
 
-    private static List BioCollectSupported =
-            [[url: 'https://creativecommons.org/publicdomain/zero/1.0/', logo: "Cc-by-pd_icon.svg.png", description: "Public Domain Dedication"],
-             [url: 'https://creativecommons.org/licenses/by-nc/2.5/', logo: "Cc-by-nc_icon.svg.png", description: "CC BY NC 2.5"],
-             [url: 'https://creativecommons.org/licenses/by/4.0/', logo: "Cc-by_icon.svg.png", description: "CC BY 4.0"],
-             [url: 'https://creativecommons.org/licenses/by-nc/3.0/au/', logo: "Cc-by-nc_icon.svg.png", description: "CC BY NC 3.0 AU"]
-            ]
-
+    private static List getSupported() {
+        [
+                [url: 'https://creativecommons.org/publicdomain/zero/1.0/', logo: "Cc-by-pd_icon.svg.png", description: "Public Domain Dedication"],
+                [url: 'https://creativecommons.org/licenses/by-nc/2.5/', logo: "Cc-by-nc_icon.svg.png", description: "CC BY NC 2.5"],
+                [url: 'https://creativecommons.org/licenses/by/4.0/', logo: "Cc-by_icon.svg.png", description: "CC BY 4.0"],
+                [url: 'https://creativecommons.org/licenses/by-nc/3.0/au/', logo: "Cc-by-nc_icon.svg.png", description: "CC BY NC 3.0 AU"]
+        ]
+    }
 
     GrailsApplication grailsApplication
     WebService webService
+    CacheService cacheService
 
     List licence() {
-        def url = "${grailsApplication.config.collectory.service.url}/licence/"
-        List licences = webService.getJson(url);
-        List bioSupported = this.BioCollectSupported;
-        for (item in bioSupported) {
-            String supported = item.url;
-            def found = licences.find {
-                supported == it.url
+        List collectoryNames = cacheService.get('collectory-licence-names', {
+            try {
+                def url = "${grailsApplication.config.collectory.service.url}/licence/"
+                def result = webService.getJson(url)
+                if (result instanceof List) {
+                    return result
+                } else {
+                    log.error("Could not get licences from collectory: '${result}'.")
+                }
+            } catch (Exception e) {
+                log.error("Could not get licences from collectory.", e)
+            }
+            return []
+        })
+
+        supported.collect { supported ->
+            def found = collectoryNames.find { retrieved ->
+                supported.url == retrieved.url
             }
             if (found) {
-                item.name = found.name
+                supported.name = found.name
             }
+            supported
         }
-        return bioSupported;
     }
-
 
 
 }

--- a/grails-app/services/au/org/ala/biocollect/merit/FormSpeciesFieldParserService.groovy
+++ b/grails-app/services/au/org/ala/biocollect/merit/FormSpeciesFieldParserService.groovy
@@ -5,6 +5,7 @@ import au.org.ala.ecodata.forms.ActivityFormService
 class FormSpeciesFieldParserService {
     MetadataService metadataService
     ActivityFormService activityFormService
+    CacheService cacheService
 
     /**
      * Get the list of species fields, for the specified survey, grouped by outputs
@@ -16,14 +17,24 @@ class FormSpeciesFieldParserService {
      * @return the list of species fields
      */
     Map getSpeciesFieldsForSurvey(String id) {
-        def model = activityFormService.getActivityAndOutputMetadata(id)
+        def cacheKey = "activityFormService-getActivityAndOutputMetadata-${id}"
+        def cachedValue = cacheService.get(cacheKey, {
+            try {
+                return activityFormService.getActivityAndOutputMetadata(id) ?: [:]
+            } catch (Exception e) {
+                log.error("Could not get activity and output metadata from activity form service.", e)
+            }
+            return [:]
+        })
+
+        def model = cachedValue
 
         def fields = []
 
         def attr = [fields: fields]
 
         // Find the species fields in the data model for each output model
-        model.outputModels.each { outputName, outputModel ->
+        model.outputModels?.each { outputName, outputModel ->
             if(outputModel) { // Yes there are a few instances were the output is null
                 attr.model = outputModel
                 attr.outputName = outputName

--- a/src/test/groovy/au/org/ala/biocollect/merit/CollectoryServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/biocollect/merit/CollectoryServiceSpec.groovy
@@ -1,0 +1,68 @@
+package au.org.ala.biocollect.merit
+
+import grails.testing.services.ServiceUnitTest
+import spock.lang.Specification
+
+class CollectoryServiceSpec extends Specification implements ServiceUnitTest<CollectoryService> {
+
+    def webServiceStub = Mock(WebService)
+    def cacheServiceStub = Mock(CacheService)
+
+    void setup() {
+        service.webService = webServiceStub
+        service.cacheService = cacheServiceStub
+    }
+
+    void "should be able to get licences when collectory is available"() {
+        given:
+        def collectoryResponse = [
+                [url: 'https://creativecommons.org/publicdomain/zero/1.0/', name: 'zero'],
+                [url: 'https://creativecommons.org/licenses/by-nc/2.5/', name: 'by-nc-2.5'],
+                [url: 'https://creativecommons.org/licenses/by/4.0/', name: 'by'],
+                [url: 'https://creativecommons.org/licenses/by-nc/3.0/au/', name: 'by-nc-3.0'],
+        ]
+
+        when:
+        def licences = service.licence()
+
+        then:
+        1 * cacheServiceStub.get('collectory-licence-names', _) >> collectoryResponse
+        0 * _
+        licences.size() == 4
+        licences.every { l ->
+                def found = collectoryResponse.find { f ->
+                f.url == l.url
+        }
+            l.url && l.logo && l.description && l.name == found.name
+        }
+    }
+
+    void "should be able to get licences when cached value is empty list"() {
+        when:
+        def licences = service.licence()
+
+        then:
+        1 * cacheServiceStub.get('collectory-licence-names', _) >> []
+        0 * _
+        licences.size() == 4
+        licences.every { it.url && it.logo && it.description && !it.name }
+    }
+
+    void "should return an empty list when the web service call fails"() {
+        given:
+        def oldCacheService = service.cacheService
+        service.cacheService = new CacheService()
+
+        when:
+        def licences = service.licence()
+
+        then:
+        1 * webServiceStub.getJson("${grailsApplication.config.collectory.service.url}/licence/") >> { throw new Exception() }
+        0 * _
+        licences.size() == 4
+        licences.every { it.url && it.logo && it.description && !it.name }
+
+        cleanup:
+        service.cacheService = oldCacheService
+    }
+}


### PR DESCRIPTION
These changes allow the project index page to load if the Collectory licence or activity form list web services fail or time out.