### PR TITLE
#1689 - added includeLinkedEntities parameter to get outputs, site and documents of a list of activities

### DIFF
--- a/grails-app/controllers/au/org/ala/biocollect/BioActivityController.groovy
+++ b/grails-app/controllers/au/org/ala/biocollect/BioActivityController.groovy
@@ -1052,9 +1052,10 @@ class BioActivityController {
             }
         }
 
-        queryParams.max = queryParams.max ?: 10
+        queryParams.max = queryParams.getInt('max', 10)
         queryParams.offset = queryParams.offset ?: 0
         queryParams.flimit = queryParams.flimit ?: 20
+        queryParams.includeLinkedEntities = queryParams.getBoolean('includeLinkedEntities', false)
         if(queryParams.flimit ==  "-1"){
             queryParams.flimit = MAX_FLIMIT;
             queryParams.max = 0;
@@ -1119,11 +1120,12 @@ class BioActivityController {
                     @Parameter(
                             name = "max",
                             in = ParameterIn.QUERY,
-                            description = "Maximum number of returned activities per page.",
+                            description = "Maximum number of returned activities per page. Maximum is 50.",
                             schema = @Schema(
                                     name = "max",
                                     type = "integer",
                                     minimum = "0",
+                                    maximum = "50",
                                     defaultValue = "10"
                             )
                     ),
@@ -1145,6 +1147,15 @@ class BioActivityController {
                             schema = @Schema(
                                     type = "string",
                                     allowableValues = ['myrecords', 'project', 'projectrecords', 'myprojectrecords', 'userprojectactivityrecords', 'allrecords', 'bulkimport']
+                            )
+                    ),
+                    @Parameter(
+                            name = "includeLinkedEntities",
+                            in = ParameterIn.QUERY,
+                            description = "Add associations to an activity such as outputs, site, documents, etc.",
+                            schema = @Schema(
+                                    type = "boolean",
+                                    defaultValue =  "false"
                             )
                     ),
                     @Parameter(
@@ -1224,6 +1235,7 @@ class BioActivityController {
     @Path("ws/bioactivity/search")
     def searchProjectActivities() {
         GrailsParameterMap queryParams = constructDefaultSearchParams(params)
+        queryParams.max = Math.min(queryParams.max, 50)
 
         Map searchResult = searchService.searchProjectActivity(queryParams)
 
@@ -1234,8 +1246,12 @@ class BioActivityController {
             it.type == 'property'
         }
 
-        activities = activities?.collect {
-            Map doc = it._source
+        activities = activities?.collect { it._source }
+        if (queryParams.includeLinkedEntities) {
+            activityService.addLinkedEntitiesToActivities(activities)
+        }
+
+        activities = activities?.collect { doc ->
             if ( !userCanModerateForProjects.hasProperty ( doc.projectId ) ) {
                 userCanModerateForProjects[doc.projectId] = projectService.canUserModerateProjects(queryParams.userId, doc.projectId)
             }
@@ -1265,6 +1281,12 @@ class BioActivityController {
             ]
 
             activityService.addAdditionalProperties(additionalPropertyConfig, doc, result)
+            if (queryParams.includeLinkedEntities) {
+                ActivityService.INCLUDE_LINKED_ENTITIES.each { key ->
+                    result[key] = doc[key]
+                }
+            }
+
             result
         }
 

--- a/grails-app/controllers/au/org/ala/biocollect/BioActivityController.groovy
+++ b/grails-app/controllers/au/org/ala/biocollect/BioActivityController.groovy
@@ -1120,12 +1120,12 @@ class BioActivityController {
                     @Parameter(
                             name = "max",
                             in = ParameterIn.QUERY,
-                            description = "Maximum number of returned activities per page. Maximum is 50.",
+                            description = "Maximum number of returned activities per page. Maximum is 100.",
                             schema = @Schema(
                                     name = "max",
                                     type = "integer",
                                     minimum = "0",
-                                    maximum = "50",
+                                    maximum = "100",
                                     defaultValue = "10"
                             )
                     ),
@@ -1235,7 +1235,7 @@ class BioActivityController {
     @Path("ws/bioactivity/search")
     def searchProjectActivities() {
         GrailsParameterMap queryParams = constructDefaultSearchParams(params)
-        queryParams.max = Math.min(queryParams.max, 50)
+        queryParams.max = Math.min(queryParams.max, 100)
 
         Map searchResult = searchService.searchProjectActivity(queryParams)
 

--- a/grails-app/services/au/org/ala/biocollect/merit/ActivityService.groovy
+++ b/grails-app/services/au/org/ala/biocollect/merit/ActivityService.groovy
@@ -265,7 +265,8 @@ class ActivityService {
     }
 
     /** @see au.org.ala.ecodata.ActivityController for a description of the criteria required. */
-    def search(criteria) {
+    def search(criteria, boolean isReporting = false) {
+        String pathPrefix = isReporting ? '/reporting' : ''
         def modifiedCriteria = new HashMap(criteria?:[:])
         // Convert dates to UTC format.
         criteria.each { key, value ->
@@ -274,7 +275,7 @@ class ActivityService {
             }
 
         }
-        webService.doPost(grailsApplication.config.ecodata.service.url+'/activity/search/', modifiedCriteria)
+        webService.doPost(grailsApplication.config.getProperty("ecodata.baseURL") + pathPrefix + '/activity/search/', modifiedCriteria)
     }
 
     def isReport(activity) {
@@ -472,7 +473,7 @@ class ActivityService {
     List<Map> addLinkedEntitiesToActivities(List<Map> activities) {
         if (activities) {
             List ids = activities.activityId
-            List<Map> linkedActivities = search([activityId: ids])?.resp?.activities
+            List<Map> linkedActivities = search([activityId: ids], true)?.resp?.activities
             if (!linkedActivities) {
                 return activities
             }

--- a/grails-app/services/au/org/ala/biocollect/merit/ActivityService.groovy
+++ b/grails-app/services/au/org/ala/biocollect/merit/ActivityService.groovy
@@ -13,6 +13,7 @@ import javax.servlet.http.HttpServletResponse
 
 class ActivityService {
     static final BATCH_SIZE = 20
+    public static final List INCLUDE_LINKED_ENTITIES = ['outputs', 'site', 'documents']
 
     GrailsApplication grailsApplication
     WebService webService
@@ -463,5 +464,31 @@ class ActivityService {
         else {
             return result.content?.subMap('data')  ?: result
         }
+    }
+
+    /**
+     * Get linked entities such as outputs, site and documents for a list of activities.
+     */
+    List<Map> addLinkedEntitiesToActivities(List<Map> activities) {
+        if (activities) {
+            List ids = activities.activityId
+            List<Map> linkedActivities = search([activityId: ids])?.resp?.activities
+            if (!linkedActivities) {
+                return activities
+            }
+
+            activities.each {activity ->
+                Map match = linkedActivities.find { activity.activityId == it.activityId }
+                if (match) {
+                    INCLUDE_LINKED_ENTITIES.each { String entity ->
+                        if (match[entity]) {
+                            activity[entity] = match[entity]
+                        }
+                    }
+                }
+            }
+        }
+
+        activities
     }
 }

--- a/src/test/groovy/au/org/ala/biocollect/merit/ActivityServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/biocollect/merit/ActivityServiceSpec.groovy
@@ -10,8 +10,14 @@ public class ActivityServiceSpec extends Specification implements AutowiredTest{
     Closure doWithSpring() {{ ->
         service ActivityService
     }}
-
+    WebService webService = Mock(WebService)
     ActivityService service
+
+    def setup() {
+        grailsApplication.config.ecodata.service.url = ''
+        service.webService = webService
+        service.grailsApplication = grailsApplication
+    }
 
     def "progress can be compared correctly"() {
 
@@ -19,5 +25,20 @@ public class ActivityServiceSpec extends Specification implements AutowiredTest{
         ['started', 'finished', 'planned'].max(service.PROGRESS_COMPARATOR) == 'finished'
         ['started', 'finished', 'planned'].min(service.PROGRESS_COMPARATOR) == 'planned'
 
+    }
+
+    def "addLinkedEntitiesToActivities should add linked entities to activities"() {
+        given:
+        def activity = [activityId: 'activity1']
+        def linkedEntity = [activityId: 'activity1', outputs: [[id: 'output1']], site: [id: 'site1'], documents: [[id: 'doc1']]]
+
+        when:
+        service.addLinkedEntitiesToActivities([activity])
+
+        then:
+        1 * webService.doPost('/activity/search/', [activityId: ['activity1']]) >> [resp: [activities: [linkedEntity]]]
+        activity.outputs == linkedEntity.outputs
+        activity.site == linkedEntity.site
+        activity.documents == linkedEntity.documents
     }
 }


### PR DESCRIPTION
- added includeLinkedEntities parameter to get outputs, site and documents of a list of activities
- restricted results to a maximum of 50 to limit load on ecodata