### PR TITLE
Hotfix/8.0.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-biocollectVersion=8.0.1
+biocollectVersion=8.0.2-SNAPSHOT
 grailsVersion=6.2.0
 grailsGradlePluginVersion=6.1.2
 assetPipelineVersion=4.3.0

--- a/grails-app/taglib/au/org/ala/biocollect/merit/FCTagLib.groovy
+++ b/grails-app/taglib/au/org/ala/biocollect/merit/FCTagLib.groovy
@@ -658,7 +658,7 @@ class FCTagLib {
         if(attrs.key){
             def content = settingService.getSettingText(attrs.key) as String
             if (content) {
-                out << markdownToHtmlAndSanitise(content)
+                out << content.markdownToHtml()
             }
         }
     }


### PR DESCRIPTION
A bug was found in the `8.0.1` release, breaking a specific set of static pages needed for the HCAT hub. The updated version fixes the bug.