### PR TITLE
Accept Cognito UUIDs for user role assignment

### DIFF
--- a/grails-app/views/admin/_addPermissions.gsp
+++ b/grails-app/views/admin/_addPermissions.gsp
@@ -63,9 +63,8 @@
                 if (email) {
                     // first check email address is a valid user
                     $.get("${g.createLink(controller:'user',action:'checkEmailExists')}?email=" + email, function(data) {
-                        const isValidUserId = /^(\d+|[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i.test(data);
-                        if (data && isValidUserId) {
-                            addUserWithRole( data, role, entityId);
+                        if (data) {
+                            addUserWithRole(data, role, entityId);
                         } else {
                             var $clone = $('.bbAlert1').clone();
                             bootbox.alert($clone.show());

--- a/grails-app/views/admin/_addPermissions.gsp
+++ b/grails-app/views/admin/_addPermissions.gsp
@@ -63,7 +63,8 @@
                 if (email) {
                     // first check email address is a valid user
                     $.get("${g.createLink(controller:'user',action:'checkEmailExists')}?email=" + email, function(data) {
-                        if (data && /^\d+$/.test(data)) {
+                        const isValidUserId = /^(\d+|[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i.test(data);
+                        if (data && isValidUserId) {
                             addUserWithRole( data, role, entityId);
                         } else {
                             var $clone = $('.bbAlert1').clone();


### PR DESCRIPTION
This pull request updates the user email validation logic in the `grails-app/views/admin/_addPermissions.gsp` file to better handle user identifiers. ~~The main change is an improvement to the way user IDs are validated, allowing both numeric IDs and now UUIDs (`aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`), as Cognito uses them - see [here](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-id-token.html)~~

The UUID validation has been replaced with a simple truthy check.

Validation logic improvement:

* ~~The check for a valid user ID now accepts both numeric IDs and UUIDs, instead of only numeric IDs, by updating the regular expression used in the validation.~~