### PR TITLE
Use hub admin check for bulk import permission

### DIFF
--- a/grails-app/taglib/au/org/ala/biocollect/merit/FCTagLib.groovy
+++ b/grails-app/taglib/au/org/ala/biocollect/merit/FCTagLib.groovy
@@ -514,6 +514,12 @@ class FCTagLib {
         }
     }
 
+    def userIsHubAdmin = { attrs ->
+        if (userService.doesUserHaveHubRole(RoleService.ADMIN_ROLE)) {
+            out << true
+        }
+    }
+
     /**
      * Build HTML for drop down menu "My projects"
      */

--- a/grails-app/views/projectActivity/_list.gsp
+++ b/grails-app/views/projectActivity/_list.gsp
@@ -139,7 +139,7 @@
                             <i class="fas fa-download me-1"></i>
                             <g:message code="project.survey.downloadTemplate"/>
                         </a>
-                        <g:if test="${fc.userIsAlaAdmin()}">
+                        <g:if test="${fc.userIsHubAdmin()}">
                         <a class="btn btn-sm btn-dark"
                            data-bind="attr: { href: bulkImportUrl}"
                            title="<g:message code="project.survey.bulkupload.title"/>">


### PR DESCRIPTION
Replace ALA admin check with hub admin check for the bulk survey import feature. Adds a new userIsHubAdmin tag library method that checks if the user has the hub admin role, and updates the project activity list view to use this check instead of the ALA admin check.